### PR TITLE
add an actual queue and multiple workers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ default-members = ["post-build-hook", "post-build-hook-queue"]
 version = "1.0.3"
 edition = "2024"
 
-authors = ["Alex Martens <alex@thinglab.org>"]
+authors = [
+  "Alex Martens <alex@thinglab.org>",
+  "Yureka Lilian <yureka@cyberchaos.dev>",
+]
 repository = "https://github.com/newAM/nix-post-build-hook-queue"
 license = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2022-present Alex Martens
+Copyright (c) 2025 Yureka Lilian
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Previously the paths were processed one by one, blocking the Unix socket once it's internal buffer was full, and this was noticeable, as the post-build-hook would start blocking when building lots of small derivations.

With this change, I introduce worker threads which can sign and push paths in parallel, while also adding a bounded channel as queue, with a configurable capacity. Only when the queue is full will the post-build-hook start blocking.